### PR TITLE
`num`のバージョンを上げる。

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,12 +279,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "gif"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,38 +417,36 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.1.42"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
 dependencies = [
  "num-bigint",
  "num-complex",
  "num-integer",
  "num-iter",
- "num-rational 0.1.42",
+ "num-rational 0.4.1",
  "num-traits",
 ]
 
 [[package]]
 name = "num-bigint"
-version = "0.1.44"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
+ "autocfg",
  "num-integer",
  "num-traits",
- "rand",
- "rustc-serialize",
 ]
 
 [[package]]
 name = "num-complex"
-version = "0.1.43"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"
+checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
  "num-traits",
- "rustc-serialize",
 ]
 
 [[package]]
@@ -480,23 +472,23 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
- "rustc-serialize",
-]
-
-[[package]]
-name = "num-rational"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -591,34 +583,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
 name = "rayon"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,15 +600,6 @@ checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -675,12 +630,6 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ name = "mylib"
 path = "./src/lib.rs"
 
 [dependencies]
-num="0.1.27"
+num="0.4"
 crossbeam = "0.8.0"
 image="0.23.12"
 


### PR DESCRIPTION
# 🐙🐬🐸🦀🦈

## 🐙🐙🐙 たこ 🐙🐙🐙

🐙🐙🐙🐙🐙 🐙🐙🐙🐙🐙 🐙🐙🐙🐙🐙  
🐙🐙🐙🐙🐙 🐙🐙🐙🐙🐙 🐙🐙🐙🐙🐙  
🐙🐙🐙🐙🐙 🐙🐙🐙🐙🐙 🐙🐙🐙🐙🐙  
🐙🐙🐙🐙🐙 🐙🐙🐙🐙🐙 🐙🐙🐙🐙🐙  
🐙🐙🐙🐙🐙 🐙🐙🐙🐙🐙 🐙🐙🐙🐙🐙  

## 🐬🐬🐬 いるか 🐬🐬🐬

🐬🐬🐬🐬🐬 🐬🐬🐬🐬🐬 🐬🐬🐬🐬🐬  
🐬🐬🐬🐬🐬 🐬🐬🐬🐬🐬 🐬🐬🐬🐬🐬  
🐬🐬🐬🐬🐬 🐬🐬🐬🐬🐬 🐬🐬🐬🐬🐬  
🐬🐬🐬🐬🐬 🐬🐬🐬🐬🐬 🐬🐬🐬🐬🐬  
🐬🐬🐬🐬🐬 🐬🐬🐬🐬🐬 🐬🐬🐬🐬🐬  

## 🐸🐸🐸 かえる 🐸🐸🐸

🐸🐸🐸🐸🐸 🐸🐸🐸🐸🐸 🐸🐸🐸🐸🐸  
🐸🐸🐸🐸🐸 🐸🐸🐸🐸🐸 🐸🐸🐸🐸🐸  
🐸🐸🐸🐸🐸 🐸🐸🐸🐸🐸 🐸🐸🐸🐸🐸  
🐸🐸🐸🐸🐸 🐸🐸🐸🐸🐸 🐸🐸🐸🐸🐸  
🐸🐸🐸🐸🐸 🐸🐸🐸🐸🐸 🐸🐸🐸🐸🐸  

## 🦀🦀🦀 かに 🦀🦀🦀

🦀🦀🦀🦀🦀 🦀🦀🦀🦀🦀 🦀🦀🦀🦀🦀  
🦀🦀🦀🦀🦀 🦀🦀🦀🦀🦀 🦀🦀🦀🦀🦀  
🦀🦀🦀🦀🦀 🦀🦀🦀🦀🦀 🦀🦀🦀🦀🦀  
🦀🦀🦀🦀🦀 🦀🦀🦀🦀🦀 🦀🦀🦀🦀🦀  
🦀🦀🦀🦀🦀 🦀🦀🦀🦀🦀 🦀🦀🦀🦀🦀  

## 🦈🦈🦈 さめ 🦈🦈🦈

🦈🦈🦈🦈🦈 🦈🦈🦈🦈🦈 🦈🦈🦈🦈🦈  
🦈🦈🦈🦈🦈 🦈🦈🦈🦈🦈 🦈🦈🦈🦈🦈  
🦈🦈🦈🦈🦈 🦈🦈🦈🦈🦈 🦈🦈🦈🦈🦈  
🦈🦈🦈🦈🦈 🦈🦈🦈🦈🦈 🦈🦈🦈🦈🦈  
🦈🦈🦈🦈🦈 🦈🦈🦈🦈🦈 🦈🦈🦈🦈🦈  
